### PR TITLE
fixed DPR class name

### DIFF
--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -61,11 +61,11 @@ ul {
 		background-position: 0 -107px;
 	}
 
-	.ubaplayer-button.playing {
+	.ubaplayer-button.ubaplayer-playing {
 		background-position: 0 -144px;
 	}
 
-	.ubaplayer-button.playing:hover {
+	.ubaplayer-button.ubaplayer-playing:hover {
 		background-position: 0 -180px;
 	}
 }


### PR DESCRIPTION
it seems that the class names for the DPR media queries got mixed.

Before this fix, the play buttons were buggy on mobile devices.

Now it works
